### PR TITLE
add close quote after punctuation

### DIFF
--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -26,7 +26,8 @@ var replacements = [
     { searchFor: /",/g, replaceWith: ',”'},    // comma outside quote mark
     { searchFor: /"\./g, replaceWith: '.”'},    // period outside quote mark (transpose only)
     { searchFor: /"\b/g, replaceWith: '“'},    //  open quote (eg, precedes a 'word boundary')
-    { searchFor: /\b"/g, replaceWith: '”'},    //  close quote (eg, is preceded by a 'word boundary') needs to be set to follow punctuation as well
+    { searchFor: /\b"/g, replaceWith: '”'},    //  close quote (eg, is preceded by a 'word boundary')
+    { searchFor: /\b([\.|,|\?|!|;|:|-|—])"/g, replaceWith: '$1”'},    //  close quote after punctuation (which is itself preceded by a 'word boundary')
     { searchFor: / - /g, replaceWith: " — "}    //  em dash with spaces surrounding it
 ];
 // using package.json script: cleanup to read README.md via cat


### PR DESCRIPTION
This is the companion to line 29 "close quote preceded by a word boundary."  

It accepts preceding characters period, question mark, exclamation mark, comma, semi-colon, colon, hyphen or dash. It does not (but perhaps should) accept a right parenthesis, right square bracket, right curly bracket or right angle bracket.