### PR TITLE
Add JavaScript Online

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Some of these links are affiliate links, meaning that if you make a purchase, I 
 
 * [FreeCodeCamp](http://www.freecodecamp.com/) Learn to build apps & work on not-for-profit projects. #exercises
 * [LearnRx](http://reactivex.io/learnrx/) #exercises
+* [JavaScript Online](https://javascript.onl) A free collection of JavaScript problems with an online judge #exercises
 * [Javascripting](https://github.com/sethvincent/javascripting) Learn JavaScript by adventuring around in the terminal #exercises
 * [Functional Javascript](https://github.com/timoxley/functional-javascript-workshop) A functional javascript workshop #exercises
 * [BrowserifyAdventure](https://github.com/substack/browserify-adventure) Learn browserify with this educational adventure #exercises


### PR DESCRIPTION
I'm adding javascript.onl to the list of exercises. It's a free collection of JS problems with an online judge. It can also be saved for offline use (everything is static). I explain a bit about the creation of it here: http://www.pesfandiar.com/blog/2016/05/12/javascript-online-hosting-static-site-cheaply

This is my first attempt at a pull request on Github, so please let me know if you'd like this in another format. Thanks