### PR TITLE
Changed Nitrous.io to HyperDev.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Some of these links are affiliate links, meaning that if you make a purchase, I 
 * [PrettyDiff](http://prettydiff.com/)
 * [Babel Repl](http://babeljs.io/repl/) The Babel REPL with compiled output
 * [ESNextBin](http://esnextb.in/) A babel powered ES6+ browser bin with npm package support.
-* [Nitrous.IO](https://www.nitrous.io/) Online IDE in the cloud with collaboration & Docker containers
+* [HyperDev](https://hyperdev.com/) Automated deployment, instant hosting and collaborative editing.
 * [Koding](https://koding.com) Online cloud development platform with video & audio collaboration
 * [updtr](https://github.com/peerigon/updtr) Keep your modules up to date
 * [Greenkeeper](https://greenkeeper.io/) Automatically opens PRs when your dependencies fall behind latest


### PR DESCRIPTION
Nitrous has been discontinued. I changed it to HyperDev.com and added a description to the link.